### PR TITLE
Lowering angular dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,10 +33,10 @@
     "karma.conf.js"
   ],
   "dependencies": {
-    "angular": "~1.4.3"
+    "angular": ">=1.3.0 <2.0.0"
   },
   "devDependencies": {
     "bardjs": "~0.1.4",
-    "angular-mocks": "~1.4.3"
+    "angular-mocks": ">=1.3.0 <2.0.0"
   }
 }


### PR DESCRIPTION
- All tests against 1.3.0 pass
- Tests against 1.2.x failed, which could be a result of bardjs's dependencies. Since that would require rewriting all of these tests I'm leaving this at >=1.3.0 for angular. 

ref: fixes #1 
